### PR TITLE
Use correct python environment

### DIFF
--- a/ripe_atlas/dns/parse-results.py
+++ b/ripe_atlas/dns/parse-results.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 import base64
 import dns.message  # provided by dnspython


### PR DESCRIPTION
This makes sure that the current python (virtual) environment is used instead of a hard-coded python path.